### PR TITLE
Using HTTP_PREFIX (when available) instead of id for path_beg.

### DIFF
--- a/ansible/roles/bamboo/files/haproxy_template.cfg
+++ b/ansible/roles/bamboo/files/haproxy_template.cfg
@@ -45,7 +45,7 @@ frontend http-in
         {{ else }}
 
         # This is the default proxy criteria
-        acl {{ $app.EscapedId }}-aclrule path_beg -i {{ $app.Id }}
+        acl {{ $app.EscapedId }}-aclrule path_beg -i {{ if $app.Env.HTTP_PREFIX }}{{ $app.Env.HTTP_PREFIX }}{{ else }}{{ $app.Id }}{{ end }}
         use_backend {{ $app.EscapedId }}-cluster if {{ $app.EscapedId }}-aclrule
         {{ end }} {{ end }}
 


### PR DESCRIPTION
* Using HTTP_PREFIX when defined.