### PR TITLE
Added docker-machines as a dependency to docker-registry

### DIFF
--- a/ansible/roles/docker-registry/meta/main.yml
+++ b/ansible/roles/docker-registry/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: docker-machines }

--- a/vagrant/multi_node/hosts/group_vars/influxdb9_servers
+++ b/vagrant/multi_node/hosts/group_vars/influxdb9_servers
@@ -1,3 +1,3 @@
 ---
 
-docker_registry: localmesos03:5000
+docker_registry: localmesos02:5000

--- a/vagrant/multi_node/hosts/localmesos-cluster
+++ b/vagrant/multi_node/hosts/localmesos-cluster
@@ -15,11 +15,14 @@ localmesos04 zk_id=3
 [slaves]
 localmesos[03:04]
 
+[docker_machines:children]
+slaves
+
 [marathon_servers]
 localmesos[02:04]
 
 [docker_registry]
-localmesos03
+localmesos02
 
 [localmesos:children]
 masters

--- a/vagrant/single_node/hosts/single
+++ b/vagrant/single_node/hosts/single
@@ -12,6 +12,9 @@ localmesos01 zk_id=1
 [slaves]
 localmesos01
 
+[docker_machines:children]
+slaves
+
 [marathon_servers]
 localmesos01
 


### PR DESCRIPTION
Tested this on my local cluster. Now even though localmesos02 is not a slave, it still gets docker installed as it is under the group "docker_registry".

@ankanm and @jordmoz Please review.