### PR TITLE
Ankan/roger 963 better urls for mesos and frameworks

### DIFF
--- a/ansible/roles/bamboo/tasks/main.yml
+++ b/ansible/roles/bamboo/tasks/main.yml
@@ -71,12 +71,21 @@
 #  tags:
 #   - bamboo
 
+#- name: Copy Haproxy template
+#  copy: src="haproxy_template.cfg" dest={{ bamboo_conf_dir }}
+#  become: yes
+#  notify: restart bamboo
+#  tags:
+#   - bamboo
+#   - haproxy-template
+
 - name: Copy Haproxy template
-  copy: src="haproxy_template.cfg" dest={{ bamboo_conf_dir }}
+  template: src="haproxy_template.cfg.j2" dest={{ bamboo_conf_dir }}/haproxy_template.cfg
   become: yes
   notify: restart bamboo
   tags:
    - bamboo
+   - haproxy-template
 
 - name: Add local HAProxy as 127.0.0.2 in /etc/hosts
   when: haproxy_local is defined

--- a/ansible/roles/bamboo/templates/haproxy_template.cfg.j2
+++ b/ansible/roles/bamboo/templates/haproxy_template.cfg.j2
@@ -1,0 +1,174 @@
+{%- raw -%}
+# Template rendered at {{ getTime }}
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        chroot /var/lib/haproxy
+        stats socket /run/haproxy/admin.sock mode 660 level admin
+        stats timeout 30s
+        user haproxy
+        group haproxy
+        daemon
+
+        # Default SSL material locations
+        ca-base /etc/ssl/certs
+        crt-base /etc/ssl/private
+
+        # Default ciphers to use on SSL-enabled listening sockets.
+        # For more information, see ciphers(1SSL).
+        # ssl-default-bind-ciphers kEECDH+aRSA+AES:kRSA+AES:+AES256:RC4-SHA:!kEDH:!LOW:!EXP:!MD5:!aNULL:!eNULL
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client  50000
+        timeout server  50000
+
+        errorfile 400 /etc/haproxy/errors/400.http
+        errorfile 403 /etc/haproxy/errors/403.http
+        errorfile 408 /etc/haproxy/errors/408.http
+        errorfile 500 /etc/haproxy/errors/500.http
+        errorfile 502 /etc/haproxy/errors/502.http
+        errorfile 503 /etc/haproxy/errors/503.http
+        errorfile 504 /etc/haproxy/errors/504.http
+
+
+# Template Customization
+frontend http-in
+        bind *:80
+        
+{% endraw %}
+        acl host_mesos hdr_beg(host) -i mesos.
+        use_backend mesos if host_mesos
+
+        acl host_marathon hdr_beg(host) -i marathon.
+        use_backend marathon if host_marathon
+
+        acl host_chronos hdr_beg(host) -i chronos.
+        use_backend chronos if host_chronos
+
+        {% if mesos_redirect_url is defined -%}
+        # Redirect mesos
+        acl ::mesos-aclrule path_beg -i /mesos
+        redirect {{ mesos_redirect_url }} if ::mesos-aclrule
+        {%- endif %}
+
+        {% if marathon_redirect_url is defined -%}
+        # Redirect marathon
+        acl ::marathon-aclrule path_beg -i /marathon
+        redirect {{ marathon_redirect_url }} if ::marathon-aclrule
+        {%- endif %}
+
+        {% if chronos_redirect_url is defined -%}
+        # Redirect chronos
+        acl ::chronos-aclrule path_beg -i /chronos
+        redirect {{ chronos_redirect_url }} if ::chronos-aclrule
+        {%- endif %}
+{% raw %}
+        {{ $services := .Services }}
+        {{ range $index, $app := .Apps }} {{ if hasKey $services $app.Id }} {{ $service := getService $services $app.Id }}
+        acl {{ $app.EscapedId }}-aclrule {{ $service.Acl}}
+        use_backend {{ $app.EscapedId }}-cluster if {{ $app.EscapedId }}-aclrule
+        {{ else }}
+
+        # This is the default proxy criteria
+        acl {{ $app.EscapedId }}-aclrule path_beg -i {{ if $app.Env.HTTP_PREFIX }}{{ $app.Env.HTTP_PREFIX }}{{ else }}{{ $app.Id }}{{ end }}
+        use_backend {{ $app.EscapedId }}-cluster if {{ $app.EscapedId }}-aclrule
+        {{ end }} {{ end }}
+
+        stats enable
+        # CHANGE: Your stats credentials
+        stats auth admin:admin
+        stats uri /haproxy_stats
+
+{{ range $index, $app := .Apps }}
+
+# Begin Backend section for {{ $app.EscapedId }}
+# Begin Tcp ports for {{ $app.EscapedId }} {{ range $external_port, $task_port := $app.TcpPorts }}
+listen {{ $app.EscapedId }}-cluster-tcp-{{ $external_port }} :{{ $external_port }}
+        mode tcp
+        option tcplog
+        balance roundrobin
+        {{ range $page, $task := $app.Tasks }}
+        server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $external_port }} {{ $task.Host }}:{{ getTaskPort $task.Ports $task_port }} {{ end }} {{ end }}
+# End Tcp ports for {{ $app.EscapedId }}
+
+backend {{ $app.EscapedId }}-cluster{{ if $app.HealthCheckPath }}
+        option httpchk GET {{ $app.HealthCheckPath }}
+        {{ end }}
+        balance leastconn
+        option httpclose
+        option forwardfor
+	{{ if $app.Env.ENABLE_SESSION_AFFINITY }}
+	cookie SERVERID insert indirect nocache
+	{{ end }}
+	# reqrep ^([^\ ]*\ ){{ $app.Id }}\/?(.*) \1\\/\2
+        {{ if $app.Env.HTTP_PORT }} {{ range $page, $task := .Tasks }}
+	  {{ if $app.Env.ENABLE_SESSION_AFFINITY }}
+	  {{ $serverhash := getServerHash $app.EscapedId $task.Host $task.Port }}
+	server {{ $serverhash }} {{ $task.Host }}:{{ $task.Port }} check cookie {{ $serverhash }}{{ if $app.HealthCheckPath }} check{{ end }}
+          {{ else }}
+        server {{ $app.EscapedId}}-{{ $task.Host }}-{{ getTaskPort $task.Ports $app.Env.HTTP_PORT }} {{ $task.Host }}:{{ getTaskPort $task.Ports $app.Env.HTTP_PORT }}{{ if $app.HealthCheckPath }} check{{ end }}
+          {{ end }}
+        {{ end }} {{ end }}
+# End Backend section for {{ $app.EscapedId }} {{ end }}
+
+{% endraw %}
+# Begin Backend section for masters
+backend mesos
+        mode http
+        balance roundrobin
+        option httpclose
+        option forwardfor
+        option httpchk /master/state.json
+        http-check expect string elected_time
+        timeout check 10s
+        {% for host in groups['masters'] -%}
+        server {{ host }}-5050 {{ host }}:5050 check inter 10s fall 1 rise 3
+        {% endfor %}
+
+backend marathon
+        mode http
+        balance roundrobin
+        option httpclose
+        option forwardfor
+        option httpchk /ping
+        timeout check 10s
+        {% for host in groups['marathon_servers'] -%}
+        server {{ host }}-8080 {{ host }}:8080 check inter 10s fall 1 rise 3
+        {% endfor %}
+
+backend chronos
+        mode http
+        balance roundrobin
+        option httpclose
+        option forwardfor
+        option httpchk /ping
+        timeout check 10s
+        {% for host in groups['chronos_servers'] -%}
+        server {{ host }}-4400 {{ host }}:4400 check inter 10s fall 1 rise 3
+        {% endfor %}
+# End Backend section for masters
+{% raw %}
+
+##
+## map service ports of marathon apps
+## ( see https://mesosphere.github.io/marathon/docs/service-discovery-load-balancing.html#ports-assignment ))
+## to haproxy frontend port
+##
+## {{ range $index, $app := .Apps }}
+## listen {{ $app.EscapedId }}_{{ $app.ServicePort }}
+##   bind *:{{ $app.ServicePort }}
+##   mode http
+##   {{ if $app.HealthCheckPath }}
+##   # option httpchk GET {{ $app.HealthCheckPath }}
+##   {{ end }}
+##   balance leastconn
+##   option forwardfor
+##         {{ range $page, $task := .Tasks }}
+##         server {{ $app.EscapedId}}-{{ $task.Host }}-{{ $task.Port }} {{ $task.Host }}:{{ $task.Port }} {{ if $app.HealthCheckPath }} check inter 30000 {{ end }} {{ end }}
+## {{ end }}
+{%- endraw -%}

--- a/ansible/roles/bamboo/templates/haproxy_template.cfg.j2
+++ b/ansible/roles/bamboo/templates/haproxy_template.cfg.j2
@@ -39,8 +39,7 @@ defaults
 # Template Customization
 frontend http-in
         bind *:80
-        
-{% endraw %}
+
         acl host_mesos hdr_beg(host) -i mesos.
         use_backend mesos if host_mesos
 
@@ -49,31 +48,11 @@ frontend http-in
 
         acl host_chronos hdr_beg(host) -i chronos.
         use_backend chronos if host_chronos
-
-        {% if mesos_redirect_url is defined -%}
-        # Redirect mesos
-        acl ::mesos-aclrule path_beg -i /mesos
-        redirect {{ mesos_redirect_url }} if ::mesos-aclrule
-        {%- endif %}
-
-        {% if marathon_redirect_url is defined -%}
-        # Redirect marathon
-        acl ::marathon-aclrule path_beg -i /marathon
-        redirect {{ marathon_redirect_url }} if ::marathon-aclrule
-        {%- endif %}
-
-        {% if chronos_redirect_url is defined -%}
-        # Redirect chronos
-        acl ::chronos-aclrule path_beg -i /chronos
-        redirect {{ chronos_redirect_url }} if ::chronos-aclrule
-        {%- endif %}
-{% raw %}
         {{ $services := .Services }}
         {{ range $index, $app := .Apps }} {{ if hasKey $services $app.Id }} {{ $service := getService $services $app.Id }}
         acl {{ $app.EscapedId }}-aclrule {{ $service.Acl}}
         use_backend {{ $app.EscapedId }}-cluster if {{ $app.EscapedId }}-aclrule
         {{ else }}
-
         # This is the default proxy criteria
         acl {{ $app.EscapedId }}-aclrule path_beg -i {{ if $app.Env.HTTP_PREFIX }}{{ $app.Env.HTTP_PREFIX }}{{ else }}{{ $app.Id }}{{ end }}
         use_backend {{ $app.EscapedId }}-cluster if {{ $app.EscapedId }}-aclrule


### PR DESCRIPTION
* Moved haproxy_template.cfg over to templating along with updates to add master/marathon/chrons nodes.
* Sendiing to mesos ui (with master detection) based on host starting with `mesos.`.
* RR into marathon and chronos ui based on host starting with `marathon.` and `chronos.`.
* Remove extra blank lines.
