### PR TITLE
Fix aaad daemon start issue and separate Nginx into its own role.

### DIFF
--- a/ansible/marathon-nodes.yml
+++ b/ansible/marathon-nodes.yml
@@ -28,5 +28,4 @@
     - common
     - java # Java must come before marathon-server
     - marathon-server
-    - { role : nginx, when : enable_nginx_auth_proxy is defined }
 

--- a/ansible/nginx.yml
+++ b/ansible/nginx.yml
@@ -1,0 +1,7 @@
+---
+# Main task for setting up Nginx and AAA daemon.
+
+- hosts: nginx_servers
+
+  roles:
+    - nginx

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -91,6 +91,13 @@
       - install
       - nginx 
 
+  - name: Copy user permissions file to the nginx conf
+    copy: src={{permissions_file_local_path}} dest="{{nginx_conf_dir}}/user-permissions.json"  mode=0644
+    become: yes
+    tags:
+      - install
+      - nginx
+
   - name: Copy AAA daemon to nginx conf directory for now
     copy: src=../../../../aaad dest={{nginx_conf_dir}}  mode=0655
     become: yes

--- a/ansible/roles/nginx/templates/aaad.conf.j2
+++ b/ansible/roles/nginx/templates/aaad.conf.j2
@@ -5,6 +5,6 @@ start on runlevel [234]
 stop on runlevel [0156]
 
 chdir {{nginx_conf_dir}}/aaad
-exec python {{nginx_conf_dir}}/aaad/aaad.py
+exec python {{nginx_conf_dir}}/aaad/aaad.py {{nginx_conf_dir}}/user-permissions.json
 respawn
 

--- a/vagrant/multi_node/hosts/localmesos-cluster
+++ b/vagrant/multi_node/hosts/localmesos-cluster
@@ -24,6 +24,9 @@ slaves
 [marathon_servers]
 localmesos[02:04]
 
+[nginx_servers]
+localmesos[02:04]
+
 [docker_registry]
 localmesos02
 

--- a/vagrant/single_node/hosts/single
+++ b/vagrant/single_node/hosts/single
@@ -21,6 +21,9 @@ slaves
 [marathon_servers]
 localmesos01
 
+[nginx_servers]
+localmesos01
+
 [docker_registry]
 localmesos01
 


### PR DESCRIPTION
1. Currently aaad daemon fails to start and is filling up its upstart logs. This PR is mainly to fix that.
2. Separating Nginx to its separate role as it should not be couple only with Marathon framework.
3. Copying the user-permission.json file to fix the issue in point 1.
4. Going forward, we want to generate the users-permissions file from google spreadsheets (similar to marathon-servers role) and not have it to be passed through --extra-vars. Will make the changes in a following PR.
5. Tested this on my local cluster. Please note: haven't added the nginx_servers group to dev, stage and prod hosts file yet.

@ankanm and @vmahedia Please review.